### PR TITLE
feat: Upgrade image model to Llama 4 Scout

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_MODEL = "llama-3.1-8b-instant";
-export const IMAGE_MODEL = "meta-llama/llama-4-maverick-17b-128e-instruct";
+export const IMAGE_MODEL = "meta-llama/llama-4-scout-17b-16e-instruct";
 export const AUDIO_TRANSCRIPTION_MODEL = "whisper-large-v3-turbo";
 
 // Production models that support tool use and function calling


### PR DESCRIPTION
Replace deprecated Llama 4 Maverick 17B 128E (deprecated March 9, 2026) with Llama 4 Scout 17B 16E, which supports native multimodal image understanding.