### PR TITLE
feat: Replace deprecated Llama 3.3 70B model with GPT OSS 120B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,9 @@ The application follows a service-oriented architecture:
 
 The app uses different Groq models for different tasks:
 - `DEFAULT_MODEL` (llama-3.1-8b-instant) - General chat
-- `ROUTING_MODEL` (llama3-70b-8192) - Determines if tools are needed and performs initial tool calls
-- `TOOL_USE_MODEL` (llama-3.3-70b-versatile) - Final response generation after tool execution
-- `IMAGE_MODEL` (meta-llama/llama-4-maverick-17b-128e-instruct) - Image understanding
+- `ROUTING_MODEL` (openai/gpt-oss-120b) - Determines if tools are needed and performs initial tool calls
+- `TOOL_USE_MODEL` (openai/gpt-oss-120b) - Final response generation after tool execution
+- `IMAGE_MODEL` (meta-llama/llama-4-scout-17b-16e-instruct) - Image understanding
 - `AUDIO_TRANSCRIPTION_MODEL` (whisper-large-v3-turbo) - Voice transcription
 
 ### Tool System

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -3,5 +3,5 @@ export const IMAGE_MODEL = "meta-llama/llama-4-scout-17b-16e-instruct";
 export const AUDIO_TRANSCRIPTION_MODEL = "whisper-large-v3-turbo";
 
 // Production models that support tool use and function calling
-export const ROUTING_MODEL = "llama-3.3-70b-versatile";
-export const TOOL_USE_MODEL = "llama-3.3-70b-versatile";
+export const ROUTING_MODEL = "openai/gpt-oss-120b";
+export const TOOL_USE_MODEL = "openai/gpt-oss-120b";


### PR DESCRIPTION
Groq is deprecating llama-3.3-70b-versatile (decommission Aug 16, 2026). Migrate ROUTING_MODEL and TOOL_USE_MODEL to the recommended replacement openai/gpt-oss-120b, and refresh the model docs in CLAUDE.md.